### PR TITLE
Very 'rough sketch' of camera/view-layer separation

### DIFF
--- a/renderer/src/index.html
+++ b/renderer/src/index.html
@@ -39,6 +39,7 @@
     <script type="text/javascript" src="logical_sprites/pbTransformObject.js"></script>
     <script type="text/javascript" src="logical_sprites/layers/pbBaseLayer.js"></script>
     <script type="text/javascript" src="logical_sprites/layers/pbSimpleLayer.js"></script>
+    <script type="text/javascript" src="logical_sprites/layers/pbCamera.js"></script>
     <script type="text/javascript" src="logical_sprites/layers/canvas/pbCanvasLayer.js"></script>
     <script type="text/javascript" src="logical_sprites/layers/webgl/pbWebGlLayer.js"></script>
     <script type="text/javascript" src="logical_sprites/images/pbBaseImage.js"></script>

--- a/renderer/src/logical_sprites/layers/pbBaseLayer.js
+++ b/renderer/src/logical_sprites/layers/pbBaseLayer.js
@@ -24,7 +24,7 @@ pbBaseLayer.prototype.constructor = pbBaseLayer;
 pbBaseLayer.prototype.__super__ = pbTransformObject;
 
 
-pbBaseLayer.prototype.create = function(_parent, _renderer, _x, _y, _z, _angleInRadians, _scaleX, _scaleY)
+pbBaseLayer.prototype.create = function(_parent, _rendererDNU, _x, _y, _z, _angleInRadians, _scaleX, _scaleY)
 {
 	// console.log("pbBaseLayer.create", _x, _y);
 	
@@ -33,8 +33,6 @@ pbBaseLayer.prototype.create = function(_parent, _renderer, _x, _y, _z, _angleIn
 
 	// TODO: add pass-through option so that layers can choose not to inherit their parent's transforms and will use the rootLayer transform instead
 	// TODO: pbBaseLayer is rotating around it's top-left corner (because there's no width/height and no anchor point??)
-
-	this.phaserRender = _renderer;
 
 	this.parent = _parent;
 	this.list = [];
@@ -67,15 +65,15 @@ pbBaseLayer.prototype.destroy = function()
 };
 
 
-pbBaseLayer.prototype.update = function(_drawList)
+pbBaseLayer.prototype.update = function(_drawList, parentTransform)
 {
 	// console.log("pbBaseLayer.update");
 	// call the pbTransformObject update for this pbBaseLayer to access the child hierarchy
-	this.super(pbBaseLayer, 'update', _drawList);
+	this.super(pbBaseLayer, 'update', _drawList, parentTransform);
 };
 
 
-pbBaseLayer.prototype.draw = function(_list)
+pbBaseLayer.prototype.draw = function(_list, renderer)
 {
 	var obj = _list[0];
 	var srf = obj.image.surface;
@@ -83,40 +81,42 @@ pbBaseLayer.prototype.draw = function(_list)
 	// debug sprite count
 	sprCountDbg += _list.length;
 
+	renderer = pbPhaserRender.renderer; // PST-punt
+
 	if (_list.length === 1)
 	{
 		if (obj.image.onGPU)
 		{
-			pbPhaserRender.renderer.graphics.drawTextureWithTransform( obj.image.onGPU, obj.transform, obj.z_order, { x:obj.image.anchorX, y:obj.image.anchorY } );
+			renderer.graphics.drawTextureWithTransform( obj.image.onGPU, obj.transform, obj.z_order, { x:obj.image.anchorX, y:obj.image.anchorY } );
 		}
 		else if (srf.rttTexture)
 		{
 			// TODO: fix hard-wired anchorX, anchorY
-			pbPhaserRender.renderer.graphics.drawTextureWithTransform( srf.rttTexture, obj.transform, obj.z_order, { x:0.5, y:1.0 } );
+			renderer.graphics.drawTextureWithTransform( srf.rttTexture, obj.transform, obj.z_order, { x:0.5, y:1.0 } );
 		}
 		else if (obj.image.isModeZ)
 		{
-			pbPhaserRender.renderer.graphics.drawModeZ( 0, obj.image, obj.transform, obj.z_order );
+			renderer.graphics.drawModeZ( 0, obj.image, obj.transform, obj.z_order );
 		}
 		else if (obj.image.is3D)
 		{
-			pbPhaserRender.renderer.graphics.drawImageWithTransform3D( 0, obj.image, obj.transform, obj.z_order );
+			renderer.graphics.drawImageWithTransform3D( 0, obj.image, obj.transform, obj.z_order );
 		}
 		else if (obj.image.toTexture != -1)
 		{
 			// TODO: fix hard-wired width,height
-			pbPhaserRender.renderer.graphics.drawImageToTextureWithTransform( 0, obj.image.toTexture, 256, 256, obj.image, obj.transform, obj.z_order );
+			renderer.graphics.drawImageToTextureWithTransform( 0, obj.image.toTexture, 256, 256, obj.image, obj.transform, obj.z_order );
 		}
 		else
 		{
 			// NOTE: use of TEXTURE0 is hard-wired for general sprite drawing
-			pbPhaserRender.renderer.graphics.drawImageWithTransform( 0, obj.image, obj.transform, obj.z_order );
+			renderer.graphics.drawImageWithTransform( 0, obj.image, obj.transform, obj.z_order );
 		}
 	}
 	else if (obj.image.isParticle)
 	{
 		// NOTE: use of TEXTURE0 is hard-wired for general sprite drawing
-		pbPhaserRender.renderer.graphics.blitDrawImages( 0, _list, obj.image.surface );
+		renderer.graphics.blitDrawImages( 0, _list, obj.image.surface );
 	}
 	else
 	{
@@ -127,17 +127,17 @@ pbBaseLayer.prototype.draw = function(_list)
 			for(var i = 0, l = _list.length; i < l; i++)
 			{
 				obj = _list[i];
-				pbPhaserRender.renderer.graphics.drawTextureWithTransform( obj.image.onGPU, obj.transform, obj.z_order, { x:obj.image.anchorX, y:obj.image.anchorY } );
+				renderer.graphics.drawTextureWithTransform( obj.image.onGPU, obj.transform, obj.z_order, { x:obj.image.anchorX, y:obj.image.anchorY } );
 			}
 		}
 		else if (srf.rttTexture)
 		{
-			pbPhaserRender.renderer.graphics.rawBatchDrawTextures( _list );
+			renderer.graphics.rawBatchDrawTextures( _list );
 		}
 		else
 		{
 			// NOTE: use of TEXTURE0 is hard-wired for general sprite drawing
-			pbPhaserRender.renderer.graphics.rawBatchDrawImages( 0, _list );
+			renderer.graphics.rawBatchDrawImages( 0, _list );
 		}
 	}
 };

--- a/renderer/src/logical_sprites/layers/pbCamera.js
+++ b/renderer/src/logical_sprites/layers/pbCamera.js
@@ -1,0 +1,80 @@
+/**
+ *
+ * pbCamera - pbTransformObject 'view' of a pbBaseLayer
+ * 
+ */
+
+
+function pbCamera()
+{
+	this.super(pbBaseLayer, 'constructor');
+
+	this.list = null;
+	this.parent = null;
+	this.phaserRender = null;
+	this.clip = null;
+}
+
+// pbBaseLayer extends from the pbTransformObject prototype chain
+// permits multiple levels of inheritance 	http://jsfiddle.net/ZWZP6/2/  
+// improvement over original answer at 		http://stackoverflow.com/questions/7300552/calling-overridden-methods-in-javascript
+pbCamera.prototype = new pbTransformObject();
+pbCamera.prototype.constructor = pbCamera;
+pbCamera.prototype.__super__ = pbTransformObject;
+
+
+pbCamera.prototype.create = function(_x, _y, _z, _angleInRadians, _scaleX, _scaleY)
+{
+	// console.log("pbCamera.create", _x, _y);
+	
+	// call the pbTransformObject create for this pbBaseLayer
+	this.super(pbBaseLayer, 'create', null, _x, _y, _z, _angleInRadians, _scaleX, _scaleY);
+
+	this.list = [];
+};
+
+
+pbCamera.prototype.setClipping = function(_x, _y, _width, _height)
+{
+	this.clip = new pbRectangle(_x, _y, _width, _height);
+};
+
+
+pbCamera.prototype.destroy = function()
+{
+	// call the pbTransformObject destroy for this pbBaseLayer
+	this.super(pbBaseLayer, 'destroy');
+
+	this.clip = null;
+
+	this.phaserRender = null;
+
+	if (this.parent && this.parent.list)
+	{
+		var i = this.parent.list.indexof(this);
+		if (i != -1)
+			this.parent.list.splice(i, 1);
+	}
+	this.parent = null;
+	this.list = null;
+};
+
+
+pbCamera.prototype.update = function(_drawList, rootLayer)
+{
+	// console.log("pbCamera.update");
+	// call the pbTransformObject update for this pbBaseLayer to access the child hierarchy
+	rootLayer.update(_drawList, this.transform);
+};
+
+
+/**
+ * override the pbTransformObject addChild function to handle case where a pbBaseLayer is added to a pbBaseLayer
+ * in that case it should go into list instead of children in order to provide the correct order of processing
+ *
+ * @param {[type]} _child [description]
+ */
+pbCamera.prototype.addChild = function( _child )
+{
+	throw new "Camera has no children"
+};

--- a/renderer/src/logical_sprites/layers/webgl/pbWebGlLayer.js
+++ b/renderer/src/logical_sprites/layers/webgl/pbWebGlLayer.js
@@ -56,7 +56,7 @@ pbWebGlLayer.prototype.destroy = function()
 };
 
 
-pbWebGlLayer.prototype.update = function(_dictionary)
+pbWebGlLayer.prototype.update = function(_dictionary, parentTransform)
 {
 	// TODO: check this dictionary implementation works correctly with nested layers, nested sprites, and combinations of both
 	// prepare the dictionary
@@ -66,7 +66,7 @@ pbWebGlLayer.prototype.update = function(_dictionary)
 	this.drawDictionary.clear();
 
 	// call the pbBaseLayer update for this pbWebGlLayer to access the child hierarchy
-	this.super(pbWebGlLayer, 'update', this.drawDictionary);
+	this.super(pbWebGlLayer, 'update', this.drawDictionary, parentTransform);
 
 	if (this.clip)
 	{

--- a/renderer/src/logical_sprites/pbTransformObject.js
+++ b/renderer/src/logical_sprites/pbTransformObject.js
@@ -113,15 +113,15 @@ pbTransformObject.prototype.destroy = function()
 };
 
 
-pbTransformObject.prototype.update = function(_drawDictionary)
+pbTransformObject.prototype.update = function(_drawDictionary, parentTransform)
 {
 	if (this.image && this.image.is3D)
-		return this.update3D(_drawDictionary);
-	return this.update2D(_drawDictionary);
+		return this.update3D(_drawDictionary, parentTransform);
+	return this.update2D(_drawDictionary, parentTransform);
 };
 
 
-pbTransformObject.prototype.update2D = function(_drawDictionary)
+pbTransformObject.prototype.update2D = function(_drawDictionary, parentTransform)
 {
 	// console.log("pbTransformObject.update");
 
@@ -131,8 +131,8 @@ pbTransformObject.prototype.update2D = function(_drawDictionary)
 	pbMatrix3.setTransform(this.transform, this.x, this.y, this.angleInRadians, this.scaleX, this.scaleY);
 
 	// multiply with the transform matrix from my parent
-	if (this.parent && this.parent.transform)
-		pbMatrix3.setFastMultiply(this.transform, this.parent.transform);
+	if (parentTransform)
+		pbMatrix3.setFastMultiply(this.transform, parentTransform);
 	
 	// draw if this sprite has an image
 	if (this.image && this.visible)
@@ -147,7 +147,7 @@ pbTransformObject.prototype.update2D = function(_drawDictionary)
 			var child = this.children[c];
 
 			// update this child
-			if (!child.update(_drawDictionary))
+			if (!child.update(_drawDictionary, this.transform))
 			{
 				child.destroy();
 				this.removechildAt(c);
@@ -159,7 +159,7 @@ pbTransformObject.prototype.update2D = function(_drawDictionary)
 };
 
 
-pbTransformObject.prototype.update3D = function(_drawDictionary)
+pbTransformObject.prototype.update3D = function(_drawDictionary, parentTransform)
 {
 	// console.log("pbTransformObject.update3D");
 
@@ -169,13 +169,13 @@ pbTransformObject.prototype.update3D = function(_drawDictionary)
 	// set my own transform matrix
 	pbMatrix4.setTransform(this.transform, this.x, this.y, this.z, this.rx, this.ry, this.rz, this.scaleX, this.scaleY, this.scaleZ);
 	// multiply with the transform matrix from my parent
-	if (this.parent && this.parent.transform)
+	if (parentTransform)
 	{
 		// parent layer might not be using 3D, convert it's 2D transformation into 3D
-		if (this.parent.transform.length == 9)
-			pbMatrix4.setFastMultiply3(this.transform, this.parent.transform);
+		if (parentTransform.length == 9)
+			pbMatrix4.setFastMultiply3(this.transform, parentTransform);
 		else
-			pbMatrix4.setFastMultiply(this.transform, this.parent.transform);
+			pbMatrix4.setFastMultiply(this.transform, parentTransform);
 	}
 	
 	// draw if this sprite has an image
@@ -191,7 +191,7 @@ pbTransformObject.prototype.update3D = function(_drawDictionary)
 			var child = this.children[c];
 
 			// update this child
-			if (!child.update(_drawDictionary))
+			if (!child.update(_drawDictionary, this.transform))
 			{
 				child.destroy();
 				this.removechildAt(c);

--- a/renderer/src/root/pbPhaserRender.js
+++ b/renderer/src/root/pbPhaserRender.js
@@ -166,7 +166,7 @@ pbPhaserRender.prototype.update = function()
 
 		// create the rootLayer container for all graphics
 		rootLayer = new layerClass();
-		rootLayer.create(null, pbPhaserRender.renderer, 0, 0, 0, 0, 1, 1);
+		rootLayer.create(null, null, 0, 0, 0, 0, 1, 1);
 		
 	    // call the game's boot callback if there's nothing left to load
 	    this.bootCallback.call( this.gameContext );

--- a/renderer/src/root/pbRenderer.js
+++ b/renderer/src/root/pbRenderer.js
@@ -138,12 +138,13 @@ pbRenderer.prototype.update = function( _callback, _context )
 	if ( _callback )
 		_callback.call( _context );
 
-	// update all object transforms then draw everything
-	if ( rootLayer )
-	{
-		// the rootLayer update will iterate the entire display list
-		rootLayer.update();
-	}
+	var camera = new pbCamera();
+	camera.create(0, 0, 0, 0, 1, 0.5);
+	camera.update([], rootLayer);
+
+	var camera = new pbCamera();
+	camera.create(0, 0, 0, 0, 0.5, 1);
+	camera.update([], rootLayer);
 
 	// postUpdate if required
 	if ( this.postUpdate )


### PR DESCRIPTION
A simple proof-of-concept of this idea and separating 'parent' ownership at the root transformation (or camera views).

The pbTransform demo renders 'two views' of the same thing.
(This is not a particularly good example, but I think it shows that the dependency can be cut.)

---

- Very primitive, but shows separation of transform from parent relation
- Physics and ensuring world (not as-render) transforms is different issue
